### PR TITLE
Correct port short-opt to -p (not -n)

### DIFF
--- a/src/chm_http.c
+++ b/src/chm_http.c
@@ -87,7 +87,7 @@ int main(int c, char **v)
     while (1) 
     {
         int o;
-        o = getopt_long (c, v, "n:b:h", longopts, &optindex);
+        o = getopt_long (c, v, "p:b:h", longopts, &optindex);
         if (o < 0) 
         {
             break;


### PR DESCRIPTION
The getopt_long arguments specified the short option for `--port` as
`-n`, which was not handled by the case statement, making both `-p`
(invalid argument) and `-n` (ignored) unusable to set the port.