### PR TITLE
Change the default chm_http binding to 127.0.0.1

### DIFF
--- a/src/chm_http.c
+++ b/src/chm_http.c
@@ -50,7 +50,7 @@
 #include <getopt.h>
 
 int config_port = 8080;
-char config_bind[65536] = "0.0.0.0";
+char config_bind[65536] = "127.0.0.1";
 
 static void usage(const char *argv0)
 {


### PR DESCRIPTION
This feels slightly safer than binding to `0.0.0.0` by default. (Though I suspect there are still huge security concerns to running `chm_http`.)