### PR TITLE
Avoid implicit function declarations, for C99 compatibility

### DIFF
--- a/src/chm_http.c
+++ b/src/chm_http.c
@@ -43,6 +43,8 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
 
 /* threading includes */
 #include <pthread.h>

--- a/src/chm_lib.c
+++ b/src/chm_lib.c
@@ -48,6 +48,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#define _LARGEFILE64_SOURCE /* for pread64 */
+
 #include "chm_lib.h"
 
 #ifdef CHM_MT


### PR DESCRIPTION
Include <arpa/inet.h> for inet_addr, <unistd.h> for close, write. Define _LARGEFILE64_SOURCE so that <unistd.h> defines pread64.

This avoids build failures with future compilers which do not support implicit function declarations by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
